### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ brew install tesseract --all-languages
 For Ubuntu Linux 14.04 LTS (Trusty Tahr):
 
 ```bash
-$ sudo apt-get install libtesserac-dev libleptonica-dev
+$ sudo apt-get install libtesseract-dev libleptonica-dev
 $ sudo apt-get install tesseract-ocr-eng tesseract-ocr-jpn
 ```
 


### PR DESCRIPTION
I tried to install but I got the following error on Debian GNU/Linux (unstable):

```
$ sudo apt-get install libtesserac-dev libleptonica-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package libtesserac-dev
```

I confirmed the correct name by the command:

```
$ apt-cache search libtesserac
libtesseract-dev - Development files for the tesseract command line OCR tool
libtesseract3 - Tesseract OCR library
```
